### PR TITLE
1 調整controllerimpl異常寫法

### DIFF
--- a/src/main/java/com/example/simpleweb/controller/EmployeeController.java
+++ b/src/main/java/com/example/simpleweb/controller/EmployeeController.java
@@ -4,6 +4,8 @@ import com.example.simpleweb.dto.EmployeeDto;
 import com.example.simpleweb.entity.Employee;
 import com.example.simpleweb.service.EmployeeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -38,20 +40,27 @@ public class EmployeeController {
     }
 
     @PostMapping("/employees/add")
-    public Employee addEmployees(@RequestBody EmployeeDto employeeDto) {
+    public ResponseEntity<String> addEmployees(@RequestBody EmployeeDto employeeDto) {
 
-        return employeeService.save(employeeService.setIdZero(employeeDto));
+        employeeService.save(employeeService.convertToEmployee(employeeDto));
+
+        return ResponseEntity.status(HttpStatus.OK).body("added success.");
     }
 
     @PostMapping("/employees/addList")
-    public List<Employee> addListEmployees(@RequestBody List<EmployeeDto> employeesdto) {
+    public ResponseEntity<String> addListEmployees(@RequestBody List<EmployeeDto> employeesdto) {
 
-        List<Employee> employees = employeesdto.stream().map(employeeDto -> {
-            Employee employee = employeeService.setIdZero(employeeDto);
-            return employee;
-        }).toList();
+//        List<Employee> employees = employeesdto.stream().map(employeeDto -> {
+//            Employee employee = employeeService.convertToEmployee(employeeDto);
+//            return employee;
+//        }).toList();
+        employeeService.saveEmployees(employeesdto.stream()
+                .map(employeeDto -> {
+                    Employee employee = employeeService.convertToEmployee(employeeDto);
+                    return employee;
+                }).toList());
 
-        return employeeService.saveEmployees(employees);
+        return ResponseEntity.status(HttpStatus.OK).body("added success.");
     }
 
     @PutMapping("/employees/update")

--- a/src/main/java/com/example/simpleweb/controller/EmployeeController.java
+++ b/src/main/java/com/example/simpleweb/controller/EmployeeController.java
@@ -1,5 +1,6 @@
 package com.example.simpleweb.controller;
 
+import com.example.simpleweb.dto.EmployeeDto;
 import com.example.simpleweb.entity.Employee;
 import com.example.simpleweb.service.EmployeeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,53 +24,59 @@ public class EmployeeController {
     }
 
     @GetMapping("/employees/{employeeId}")
-    public Employee getEmployee(@PathVariable int employeeId) {
+    public Employee getEmployee(@PathVariable int employeeId) throws Exception {
+
         try {
             Employee employee = employeeService.findById(employeeId);
 
             return employee;
-        } catch (RuntimeException e) {
-            throw new RuntimeException(e);
+
+        } catch (Exception e) {
+
+            throw new Exception(e);
         }
     }
 
     @PostMapping("/employees/add")
-    public Employee addEmployees(@RequestBody Employee employee) {
+    public Employee addEmployees(@RequestBody EmployeeDto employeeDto) {
 
-//        萬一在 JSON 中傳遞 id ...將 id 設置為 0
-//        這是為了強制保存新employee ...而不是更新
-        employee.setId(0);
-
-        Employee dbEmployee = employeeService.save(employee);
-
-        return dbEmployee;
+        return employeeService.save(employeeService.setIdZero(employeeDto));
     }
 
     @PostMapping("/employees/addList")
-    public List<Employee> addListEmployees(@RequestBody List<Employee> employees) {
+    public List<Employee> addListEmployees(@RequestBody List<EmployeeDto> employeesdto) {
 
-        employees.forEach(employee -> employee.setId(0));
+        List<Employee> employees = employeesdto.stream().map(employeeDto -> {
+            Employee employee = employeeService.setIdZero(employeeDto);
+            return employee;
+        }).toList();
 
-        List<Employee> dbEmployees = employeeService.saveEmployees(employees);
-
-        return dbEmployees;
+        return employeeService.saveEmployees(employees);
     }
 
     @PutMapping("/employees/update")
-    public Employee updateEmployee (@RequestBody Employee employee) {
+    public Employee updateEmployee (@RequestBody Employee employee) throws Exception {
+
         try {
             Employee existingEmployee = employeeService.findById(employee.getId());
 
-            Employee dbEmployee = employeeService.save(employee);
+            Employee dbEmployee = null;
+
+            if (existingEmployee != null) {
+
+                dbEmployee = employeeService.save(employee);
+            }
 
             return dbEmployee;
-        } catch (RuntimeException e) {
-            throw new RuntimeException(e);
+
+        } catch (Exception e) {
+
+            throw new Exception(e);
         }
     }
 
     @DeleteMapping("/employees/delete/{employeeId}")
-    public String deleteEmployee (@PathVariable int employeeId) {
+    public String deleteEmployee (@PathVariable int employeeId) throws Exception {
 
         try {
             Employee tempEmployee = employeeService.findById(employeeId);
@@ -77,8 +84,10 @@ public class EmployeeController {
             employeeService.deleteById(employeeId);
 
             return "Delete employee id: " + employeeId;
-        } catch (RuntimeException e) {
-            throw new RuntimeException(e);
+
+        } catch (Exception e) {
+
+            throw new Exception(e);
         }
     }
 }

--- a/src/main/java/com/example/simpleweb/controller/EmployeePageController.java
+++ b/src/main/java/com/example/simpleweb/controller/EmployeePageController.java
@@ -1,23 +1,22 @@
 package com.example.simpleweb.controller;
 
-import com.example.simpleweb.dao.EmployeeRepository;
 import com.example.simpleweb.entity.Employee;
+import com.example.simpleweb.service.EmployeeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @Controller
 @RequestMapping("/employees")
 public class EmployeePageController {
 
-    private EmployeeRepository employeeService;
+    private EmployeeService employeeService;
 
     @Autowired
-    public EmployeePageController(EmployeeRepository theEmployeeService) {
+    public EmployeePageController(EmployeeService theEmployeeService) {
         employeeService = theEmployeeService;
     }
 
@@ -49,7 +48,7 @@ public class EmployeePageController {
     public String showFormForUpdate(@RequestParam("employeeId") int theId, Model theModel) {
 
 //        get the employee from the service
-        Optional<Employee> employee = employeeService.findById(theId);
+        Employee employee = employeeService.findById(theId);
 
 //        set employee in the model to prepopulate the form
         theModel.addAttribute("employee", employee);

--- a/src/main/java/com/example/simpleweb/dto/EmployeeDto.java
+++ b/src/main/java/com/example/simpleweb/dto/EmployeeDto.java
@@ -1,0 +1,11 @@
+package com.example.simpleweb.dto;
+
+import lombok.Data;
+
+@Data
+public class EmployeeDto {
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String role;
+}

--- a/src/main/java/com/example/simpleweb/service/EmployeeService.java
+++ b/src/main/java/com/example/simpleweb/service/EmployeeService.java
@@ -1,5 +1,6 @@
 package com.example.simpleweb.service;
 
+import com.example.simpleweb.dto.EmployeeDto;
 import com.example.simpleweb.entity.Employee;
 
 import java.util.List;
@@ -15,5 +16,7 @@ public interface EmployeeService {
     List<Employee> saveEmployees(List<Employee> employees);
 
     void deleteById(int theId);
+
+    Employee setIdZero (EmployeeDto employeeDto);
 
 }

--- a/src/main/java/com/example/simpleweb/service/EmployeeService.java
+++ b/src/main/java/com/example/simpleweb/service/EmployeeService.java
@@ -17,6 +17,6 @@ public interface EmployeeService {
 
     void deleteById(int theId);
 
-    Employee setIdZero (EmployeeDto employeeDto);
+    Employee convertToEmployee(EmployeeDto employeeDto);
 
 }

--- a/src/main/java/com/example/simpleweb/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/example/simpleweb/service/EmployeeServiceImpl.java
@@ -43,7 +43,7 @@ public class EmployeeServiceImpl implements EmployeeService {
     }
 
     @Override
-    public Employee setIdZero(EmployeeDto employeeDto) {
+    public Employee convertToEmployee(EmployeeDto employeeDto) {
         Employee employee = new Employee();
         employee.setId(0);
         employee.setFirstName(employeeDto.getFirstName());

--- a/src/main/java/com/example/simpleweb/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/example/simpleweb/service/EmployeeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.simpleweb.service;
 
 import com.example.simpleweb.dao.EmployeeRepository;
+import com.example.simpleweb.dto.EmployeeDto;
 import com.example.simpleweb.entity.Employee;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,8 +24,7 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Override
     public Employee findById(int theId) {
-        return employeeRepository.findById(theId)
-                .orElseThrow(()->new RuntimeException("Don't find employee id: " + theId));
+        return employeeRepository.findById(theId).orElse(null);
     }
 
     @Override
@@ -40,5 +40,16 @@ public class EmployeeServiceImpl implements EmployeeService {
     @Override
     public void deleteById(int theId) {
         employeeRepository.deleteById(theId);
+    }
+
+    @Override
+    public Employee setIdZero(EmployeeDto employeeDto) {
+        Employee employee = new Employee();
+        employee.setId(0);
+        employee.setFirstName(employeeDto.getFirstName());
+        employee.setLastName(employeeDto.getLastName());
+        employee.setEmail(employeeDto.getEmail());
+        employee.setRole(employeeDto.getRole());
+        return employee;
     }
 }


### PR DESCRIPTION
1. 新增 EmployeeDto 類別，定義員工資料傳輸字段。
2. 新增convertToEmployee方法到 EmployeeService，將employee物件 id 設定為0，強制資料庫生成新的 id，而不會意外更新現有資料。
3. 修正 EmployeePageController 的 EmployeeService 依賴注入錯誤
4. 重構 addListEmployees 和 addEmployees 方法，將 EmployeeDto 轉換為 Employee 並重設 id 為 0，以確保新增操作不更新現有數據。
5. 新增 throw Exception 在 getEmployee、updateEmployee 和 deleteEmployee 方法中，以統一異常處理。
6. 重構 addListEmployees 和 addEmployees 方法，會return Http狀態碼200